### PR TITLE
Fix test by setting host

### DIFF
--- a/test/timeout.js
+++ b/test/timeout.js
@@ -9,12 +9,14 @@ var createSbot = require('ssb-server')
 var alice = createSbot({
   temp: 'ooo_a',
   timeout: 1000,
+  host: 'localhost',
   port: 34597,
   keys: ssbKeys.generate()
 })
 var bob = createSbot({
   temp: 'ooo_b',
   timeout: 1000,
+  host: 'localhost',
   port: 34598,
   keys: ssbKeys.generate()
 })


### PR DESCRIPTION
Without this the tests say:


```
Listening on false:34597 (multiserver net plugin)
Listening on localhost:34598 (multiserver net plugin)
Listening on false:34599 (multiserver net plugin)
```