### PR TITLE
Fix race condition

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 var tape = require('tape')
 var ssbKeys = require('ssb-keys')
 var path = require('path')
-var rmrf = require('rimraf')
 
 var createSbot = require('ssb-server')
   .use(require('..'))
@@ -16,7 +15,7 @@ var bob = createSbot({
   temp: 'ooo_b',
   timeout: 1000,
   port: 34598,
-  host: 'localhost', timeout: 20001,
+  host: 'localhost',
   replicate: {hops: 3, legacy: false},
   keys: ssbKeys.generate()
 })

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -6,20 +6,21 @@ var rmrf = require('rimraf')
 var createSbot = require('ssb-server')
   .use(require('..'))
 
-var alice = createSbot({
-  temp: 'ooo_a',
-  timeout: 1000,
-  port: 34597,
-  keys: ssbKeys.generate()
-})
-var bob = createSbot({
-  temp: 'ooo_b',
-  timeout: 1000,
-  port: 34598,
-  keys: ssbKeys.generate()
-})
 
 tape('connect', function (t) {
+  var alice = createSbot({
+    temp: 'ooo_a',
+    timeout: 1000,
+    port: 34597,
+    keys: ssbKeys.generate()
+  })
+  var bob = createSbot({
+    temp: 'ooo_b',
+    timeout: 1000,
+    port: 34598,
+    keys: ssbKeys.generate()
+  })
+
   bob.once('multiserver:listening', function () {
     bob.publish({type: 'test', ooo: true}, function (err, msg) {
       console.log(msg)

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,7 +1,5 @@
 var tape = require('tape')
 var ssbKeys = require('ssb-keys')
-var path = require('path')
-var rmrf = require('rimraf')
 
 var createSbot = require('ssb-server')
   .use(require('..'))


### PR DESCRIPTION
This resolves a race condition with the new event emitter for `"multiserver:listening"` and removes some unused variables as well. When running `bob.once('multiserver:listening', fn)` we need to make sure that the server was created *very* recently, otherwise the event happens before the listener is configured.

Another race condition with the same problem: https://github.com/ssbc/ssb-blobs/pull/13